### PR TITLE
FIX: wake word frame buffering, TTS multi-channel audio, remove push-to-talk fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,6 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pre-commit>=3.0.0",
 ]
-wake-word = [
-    "pvporcupine>=3.0",
-    "torch>=2.0",
-]
 
 [project.scripts]
 max-ai = "max_ai.cli:run_voice_cli"

--- a/src/max_ai/cli.py
+++ b/src/max_ai/cli.py
@@ -38,6 +38,14 @@ async def main() -> None:
         )
         return
 
+    if not settings.picovoice_access_key:
+        from rich.console import Console
+
+        Console().print(
+            "[red]Error:[/] MAX_AI_PICOVOICE_ACCESS_KEY is not set. Add it to your .env file."
+        )
+        return
+
     async with (
         ConversationService(),
         DocumentService() as document_service,
@@ -61,19 +69,12 @@ async def main() -> None:
         tool_registry.register(TimerTool(timer_queue))
         tool_registry.register(SetNextStateTool(agent))
 
-        # Mode detection: wake-word if Picovoice key + Deepgram key are set,
-        # otherwise fall back to push-to-talk (Enter key).
-        if settings.picovoice_access_key and settings.deepgram_api_key:
-            from max_ai.voice.wakeword import WakeWordDetector
+        from max_ai.voice.wakeword import WakeWordDetector
 
-            wake_word_detector: object = WakeWordDetector(
-                settings.picovoice_access_key,
-                settings.porcupine_keyword_path,
-            )
-        else:
-            from max_ai.voice.wakeword import KeyboardWakeWordDetector
-
-            wake_word_detector = KeyboardWakeWordDetector()
+        wake_word_detector = WakeWordDetector(
+            settings.picovoice_access_key,
+            settings.porcupine_keyword_path,
+        )
 
         tts_player = TTSPlayer(
             api_key=settings.elevenlabs_api_key,
@@ -87,7 +88,7 @@ async def main() -> None:
 
         orchestrator = Orchestrator(
             audio_capture=audio_capture,
-            wake_word_detector=wake_word_detector,  # type: ignore[arg-type]
+            wake_word_detector=wake_word_detector,
             transcriber=transcriber,
             agent=agent,
             tts_player=tts_player,

--- a/src/max_ai/config.py
+++ b/src/max_ai/config.py
@@ -48,13 +48,12 @@ class Settings(BaseSettings):
     elevenlabs_stt_language: str = "en"  # ISO 639-1 code; passed to ElevenLabs STT
 
     # Run: python -c "import sounddevice; print(sounddevice.query_devices())" to list devices.
-    # Optional sounddevice output device index for TTS playback.
+    # Set to the index of your desired output device for TTS playback.
     tts_output_device: int | None = None
 
-    # Optional sounddevice input device index for voice recording.
-    # TIP: Set voice_input_device to your built-in mic (e.g. MacBook Pro Microphone) so that
-    # Bluetooth headphones stay on A2DP (high-quality) instead of switching to HFP when the
-    # microphone stream opens.
+    # Set to the index of your desired input device for voice recording.
+    # TIP: Set this to your built-in mic so Bluetooth headphones stay on A2DP
+    # instead of switching to HFP when the microphone stream opens.
     voice_input_device: int | None = None
 
     # Logging

--- a/src/max_ai/voice/display.py
+++ b/src/max_ai/voice/display.py
@@ -30,20 +30,30 @@ class Display(Protocol):
 
     def on_tool_use(self, tool_names: list[str]) -> None: ...
 
+    def on_user_input(self, transcript: str) -> None: ...
+
 
 class TerminalDisplay:
     """Single-line status display using Rich."""
 
     def __init__(self) -> None:
         self._console = Console()
+        self._at_agent_start = True
 
     def on_state_change(self, previous: AssistantState, current: AssistantState) -> None:
         label = _STATE_ICONS.get(current, current.value)
-        self._console.print(f"\r[dim]{label}[/]", end="")
+        self._at_agent_start = True
+        self._console.print(f"\n[dim]{label}[/]", end="")
 
     def on_agent_text(self, text: str) -> None:
+        if self._at_agent_start:
+            self._console.print("\nAgent: ", end="")
+            self._at_agent_start = False
         self._console.print(text, end="")
 
     def on_tool_use(self, tool_names: list[str]) -> None:
         label = ", ".join(tool_names)
-        self._console.print(f"\r[dim]⚙ {label}…[/]", end="")
+        self._console.print(f"\n[dim]⚙ {label}…[/]", end="")
+
+    def on_user_input(self, transcript: str) -> None:
+        self._console.print(f"\nYou: {transcript}")

--- a/src/max_ai/voice/orchestrator.py
+++ b/src/max_ai/voice/orchestrator.py
@@ -35,9 +35,7 @@ if TYPE_CHECKING:
     from max_ai.voice.display import Display
     from max_ai.voice.transcribe import StreamingTranscriber
     from max_ai.voice.tts import TTSPlayer
-    from max_ai.voice.wakeword import KeyboardWakeWordDetector, WakeWordDetector
-
-    AnyWakeWordDetector = WakeWordDetector | KeyboardWakeWordDetector
+    from max_ai.voice.wakeword import WakeWordDetector
 
 _logger = logging.getLogger(__name__)
 
@@ -53,7 +51,7 @@ class Orchestrator:
     def __init__(
         self,
         audio_capture: AudioCapture,
-        wake_word_detector: AnyWakeWordDetector,
+        wake_word_detector: WakeWordDetector,
         transcriber: StreamingTranscriber,
         agent: Agent,
         tts_player: TTSPlayer,
@@ -73,18 +71,14 @@ class Orchestrator:
         self._response_buffer: list[str] = []
         self._tts_stop_event = asyncio.Event()
         self._queued_events: list[UtteranceEnd | TimerFired | TaskResult] = []
-        self._keyboard_task: asyncio.Task[None] | None = None
 
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
     async def run(self) -> None:
-        """Start the orchestrator loop.  Returns when keyboard detector exits."""
-        from max_ai.voice.wakeword import KeyboardWakeWordDetector
-
-        if isinstance(self._wake_word_detector, KeyboardWakeWordDetector):
-            self._keyboard_task = asyncio.create_task(self._wake_word_detector.run(self._bus))
+        """Start the orchestrator loop."""
+        self._display.on_state_change(self._state, self._state)
 
         async with self._audio_capture.running(self._bus):
             while True:
@@ -92,13 +86,6 @@ class Orchestrator:
                 should_stop = await self._dispatch(event)
                 if should_stop:
                     break
-
-        if self._keyboard_task is not None and not self._keyboard_task.done():
-            self._keyboard_task.cancel()
-            try:
-                await self._keyboard_task
-            except asyncio.CancelledError:
-                pass
 
     # ------------------------------------------------------------------
     # State transitions
@@ -207,12 +194,9 @@ class Orchestrator:
     # ------------------------------------------------------------------
 
     async def _handle_audio_frame(self, data: bytes) -> None:
-        from max_ai.voice.wakeword import WakeWordDetector
-
         if self._state == AssistantState.IDLE:
-            if isinstance(self._wake_word_detector, WakeWordDetector):
-                if self._wake_word_detector.process(data):
-                    await self._bus.put(WakeWordDetected())
+            if self._wake_word_detector.process(data):
+                await self._bus.put(WakeWordDetected())
         elif self._state == AssistantState.LISTENING:
             await self._transcriber.send(data)
 
@@ -224,6 +208,7 @@ class Orchestrator:
                 self._transition(AssistantState.IDLE)
                 return
             await self._transcriber.stop()
+            self._display.on_user_input(transcript)
             self._transition(AssistantState.PROCESSING)
             asyncio.create_task(self._agent_task(transcript))
         elif self._state in (AssistantState.PROCESSING, AssistantState.SPEAKING):

--- a/src/max_ai/voice/tts.py
+++ b/src/max_ai/voice/tts.py
@@ -65,6 +65,9 @@ async def speak(
     audio = _pitch_shift(np.frombuffer(pcm_bytes, dtype=np.int16))
 
     def _play(thread_stop_event: threading.Event | None) -> None:
+        device_info = sd.query_devices(output_device, "output")
+        channel_count = max(1, min(int(device_info["max_output_channels"]), 2))
+
         position = 0
         done = threading.Event()
 
@@ -80,14 +83,16 @@ async def speak(
                 outdata[:] = 0
                 raise sd.CallbackStop
             frames_to_write = min(frames, remaining)
-            outdata[:frames_to_write, 0] = audio[position : position + frames_to_write]
+            chunk = audio[position : position + frames_to_write]
+            for channel_index in range(channel_count):
+                outdata[:frames_to_write, channel_index] = chunk
             if frames_to_write < frames:
                 outdata[frames_to_write:] = 0
             position += frames_to_write
 
         with sd.OutputStream(
             samplerate=_SAMPLE_RATE,
-            channels=1,
+            channels=channel_count,
             dtype="int16",
             device=output_device,
             callback=callback,

--- a/src/max_ai/voice/wakeword.py
+++ b/src/max_ai/voice/wakeword.py
@@ -1,39 +1,10 @@
-"""Wake-word detection components.
-
-WakeWordDetector wraps Porcupine (pvporcupine, lazy import).
-KeyboardWakeWordDetector is the push-to-talk fallback: Enter key fires
-WakeWordDetected, so the orchestrator is unchanged.
-"""
+"""Wake-word detection via Porcupine (pvporcupine, lazy import)."""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import sys
-from collections.abc import Callable
-
-from max_ai.voice.events import EventBus, WakeWordDetected
 
 _logger = logging.getLogger(__name__)
-
-
-def _make_key_press_handler(future: asyncio.Future[str]) -> Callable[[], None]:
-    """Return a stdin reader callback bound to a specific future.
-
-    Extracted to module level to satisfy B023 (function in loop must not
-    capture loop variables by reference).
-    """
-
-    def _on_key_press() -> None:
-        character = sys.stdin.read(1)
-        if character in ("\n", "\r"):
-            if not future.done():
-                future.set_result("enter")
-        elif character.lower() == "x":
-            if not future.done():
-                future.set_result("x")
-
-    return _on_key_press
 
 
 class WakeWordDetector:
@@ -52,17 +23,28 @@ class WakeWordDetector:
             )
         else:
             self._porcupine = pvporcupine.create(access_key=access_key, keywords=["porcupine"])
+        self._buffer: bytes = b""
 
     def process(self, audio_frame: bytes) -> bool:
-        """Feed exactly frame_length int16 samples. Returns True on detection."""
+        """Buffer incoming bytes and call _porcupine.process once per full frame.
+
+        Audio chunks from sounddevice may be smaller than frame_length, so we
+        accumulate samples until we have exactly frame_length int16 values, then
+        process all complete frames and return True if any triggered detection.
+        """
         import struct
 
-        samples_count = len(audio_frame) // 2
-        samples = list(struct.unpack(f"{samples_count}h", audio_frame))
-        result: int = self._porcupine.process(samples)
-        detected = result >= 0
-        if detected:
-            _logger.debug("wake word detected")
+        self._buffer += audio_frame
+        required_bytes = self.frame_length * 2
+        detected = False
+        while len(self._buffer) >= required_bytes:
+            chunk = self._buffer[:required_bytes]
+            self._buffer = self._buffer[required_bytes:]
+            samples = list(struct.unpack(f"{self.frame_length}h", chunk))
+            result: int = self._porcupine.process(samples)
+            if result >= 0:
+                _logger.debug("wake word detected")
+                detected = True
         return detected
 
     @property
@@ -77,39 +59,3 @@ class WakeWordDetector:
 
     def close(self) -> None:
         self._porcupine.delete()
-
-
-class KeyboardWakeWordDetector:
-    """Push-to-talk fallback: Enter key triggers WakeWordDetected.
-
-    Runs as a background task while the orchestrator is in IDLE state.
-    Pressing Enter puts WakeWordDetected onto the bus.
-    Pressing 'x' puts None (signals shutdown) — callers must handle it.
-    """
-
-    async def run(self, bus: EventBus) -> None:
-        """Listen for Enter/x in a non-blocking way.  Runs until cancelled."""
-        _logger.debug("keyboard wake-word detector start")
-        import termios
-        import tty
-
-        loop = asyncio.get_running_loop()
-
-        while True:
-            future: asyncio.Future[str] = loop.create_future()
-            fd = sys.stdin.fileno()
-            old_settings = termios.tcgetattr(fd)
-            tty.setcbreak(fd)
-
-            loop.add_reader(fd, _make_key_press_handler(future))
-            try:
-                key = await future
-            finally:
-                loop.remove_reader(fd)
-                termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
-
-            if key == "enter":
-                await bus.put(WakeWordDetected())
-            elif key == "x":
-                # Signal shutdown by putting a sentinel; orchestrator handles it.
-                return

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,90 @@
+"""Tests for CLI entry point."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from max_ai.voice.orchestrator import Orchestrator
+from max_ai.voice.wakeword import WakeWordDetector
+
+
+def _make_async_context_manager() -> MagicMock:
+    mock = MagicMock()
+    mock.__aenter__ = AsyncMock(return_value=mock)
+    mock.__aexit__ = AsyncMock(return_value=None)
+    return mock
+
+
+class _NoOpTaskGroup:
+    """Replaces asyncio.TaskGroup so main() exits without running tasks."""
+
+    async def __aenter__(self) -> _NoOpTaskGroup:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    def create_task(self, coroutine: object) -> None:
+        if asyncio.iscoroutine(coroutine):
+            coroutine.close()
+
+
+async def test_main_uses_wake_word_detector() -> None:
+    """main() always instantiates WakeWordDetector (wake-word is a project requirement)."""
+    captured_wake_word_detector: list[object] = []
+
+    mock_orchestrator = cast(Orchestrator, MagicMock(spec=Orchestrator))
+    mock_orchestrator.run = AsyncMock()  # type: ignore[method-assign]
+
+    def _capturing_orchestrator(**kwargs: object) -> Orchestrator:
+        captured_wake_word_detector.append(kwargs.get("wake_word_detector"))
+        return mock_orchestrator
+
+    fake_porcupine = MagicMock()
+    fake_porcupine.frame_length = 512
+    fake_porcupine.sample_rate = 16000
+    fake_pvporcupine = MagicMock()
+    fake_pvporcupine.create.return_value = fake_porcupine
+
+    with (
+        patch("max_ai.cli.settings") as mock_settings,
+        patch("max_ai.cli.setup_langwatch"),
+        patch("max_ai.cli.ConversationService", return_value=_make_async_context_manager()),
+        patch("max_ai.cli.DocumentService", return_value=_make_async_context_manager()),
+        patch("max_ai.cli.create_client", return_value=MagicMock()),
+        patch("max_ai.cli.ToolRegistry", return_value=MagicMock()),
+        patch("max_ai.cli.DocumentTools", return_value=MagicMock()),
+        patch("max_ai.cli.CalendarTools", return_value=MagicMock()),
+        patch("max_ai.cli.AlarmTool", return_value=MagicMock()),
+        patch("max_ai.cli.TimerTool", return_value=MagicMock()),
+        patch("max_ai.cli.SetNextStateTool", return_value=MagicMock()),
+        patch("max_ai.cli.load_agent_prompt", return_value=""),
+        patch("max_ai.cli.Agent", return_value=MagicMock()),
+        patch("max_ai.cli.TTSPlayer", return_value=MagicMock()),
+        patch("max_ai.cli.StreamingTranscriber", return_value=MagicMock()),
+        patch("max_ai.cli.AudioCapture", return_value=MagicMock()),
+        patch("max_ai.cli.TerminalDisplay", return_value=MagicMock()),
+        patch("max_ai.cli.Orchestrator", side_effect=_capturing_orchestrator),
+        patch("sys.modules", {**__import__("sys").modules, "pvporcupine": fake_pvporcupine}),
+        patch("asyncio.TaskGroup", _NoOpTaskGroup),
+    ):
+        mock_settings.log_level = "WARNING"
+        mock_settings.elevenlabs_api_key = "test-elevenlabs-key"
+        mock_settings.picovoice_access_key = "test-picovoice-key"
+        mock_settings.porcupine_keyword_path = ""
+        mock_settings.spotify_client_id = ""
+        mock_settings.spotify_client_secret = ""
+        mock_settings.vad_min_words = 3
+        mock_settings.elevenlabs_voice_id = "test-voice"
+        mock_settings.elevenlabs_tts_model = "test-model"
+        mock_settings.tts_output_device = None
+        mock_settings.voice_input_device = None
+
+        from max_ai.cli import main
+
+        await main()
+
+    assert len(captured_wake_word_detector) == 1
+    assert isinstance(captured_wake_word_detector[0], WakeWordDetector)

--- a/tests/voice/test_display.py
+++ b/tests/voice/test_display.py
@@ -45,8 +45,25 @@ def test_on_state_change_prints_speaking_label() -> None:
     assert "speaking" in printed
 
 
-def test_on_agent_text_prints_text() -> None:
+def test_on_state_change_resets_agent_start_flag() -> None:
+    display, _ = _make_display_with_mock_console()
+    display._at_agent_start = False
+    display.on_state_change(AssistantState.LISTENING, AssistantState.PROCESSING)
+    assert display._at_agent_start is True
+
+
+def test_on_agent_text_prints_prefix_on_first_call() -> None:
     display, mock_console = _make_display_with_mock_console()
+    display.on_agent_text("Hello, world!")
+    calls = cast(MagicMock, mock_console.print).call_args_list
+    assert len(calls) == 2
+    assert calls[0][0][0] == "\nAgent: "
+    assert calls[1][0][0] == "Hello, world!"
+
+
+def test_on_agent_text_no_prefix_on_subsequent_calls() -> None:
+    display, mock_console = _make_display_with_mock_console()
+    display._at_agent_start = False
     display.on_agent_text("Hello, world!")
     mock_console.print.assert_called_once_with("Hello, world!", end="")
 
@@ -57,3 +74,11 @@ def test_on_tool_use_prints_tool_names() -> None:
     printed = cast(MagicMock, mock_console.print).call_args[0][0]
     assert "spotify" in printed
     assert "calendar" in printed
+
+
+def test_on_user_input_prints_transcript() -> None:
+    display, mock_console = _make_display_with_mock_console()
+    display.on_user_input("hello world")
+    printed = cast(MagicMock, mock_console.print).call_args[0][0]
+    assert "hello world" in printed
+    assert "You:" in printed

--- a/tests/voice/test_logging.py
+++ b/tests/voice/test_logging.py
@@ -10,16 +10,16 @@ from tests.voice.test_orchestrator import (
     _make_agent_with_responses,
     _make_mock_audio_capture,
     _make_mock_display,
-    _make_mock_keyboard_detector,
     _make_mock_transcriber,
     _make_mock_tts_player,
+    _make_mock_wake_word_detector,
 )
 
 
 def _make_orchestrator() -> Orchestrator:
     return Orchestrator(
         audio_capture=_make_mock_audio_capture(),
-        wake_word_detector=_make_mock_keyboard_detector(),
+        wake_word_detector=_make_mock_wake_word_detector(),
         transcriber=_make_mock_transcriber(),
         agent=_make_agent_with_responses([AgentDone(next_state=None)]),
         tts_player=_make_mock_tts_player(),

--- a/tests/voice/test_orchestrator.py
+++ b/tests/voice/test_orchestrator.py
@@ -4,6 +4,7 @@ All components are mocked.  The bus is driven directly so no real audio,
 network, or TTS calls are made.
 """
 
+import asyncio
 from collections.abc import AsyncIterator
 from typing import cast
 from unittest.mock import AsyncMock, MagicMock
@@ -28,7 +29,7 @@ from max_ai.voice.events import (
 from max_ai.voice.orchestrator import Orchestrator, OrchestratorConfig
 from max_ai.voice.transcribe import StreamingTranscriber
 from max_ai.voice.tts import TTSPlayer
-from max_ai.voice.wakeword import KeyboardWakeWordDetector
+from max_ai.voice.wakeword import WakeWordDetector
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -67,9 +68,8 @@ def _make_mock_tts_player() -> TTSPlayer:
     return player
 
 
-def _make_mock_keyboard_detector() -> KeyboardWakeWordDetector:
-    detector = cast(KeyboardWakeWordDetector, MagicMock(spec=KeyboardWakeWordDetector))
-    detector.run = AsyncMock()  # type: ignore[method-assign]
+def _make_mock_wake_word_detector() -> WakeWordDetector:
+    detector = cast(WakeWordDetector, MagicMock(spec=WakeWordDetector))
     return detector
 
 
@@ -99,12 +99,40 @@ def _make_orchestrator(
 ) -> Orchestrator:
     return Orchestrator(
         audio_capture=_make_mock_audio_capture(),
-        wake_word_detector=_make_mock_keyboard_detector(),
+        wake_word_detector=_make_mock_wake_word_detector(),
         transcriber=transcriber or _make_mock_transcriber(),
         agent=agent or _make_agent_with_responses([AgentDone(next_state=None)]),
         tts_player=tts_player or _make_mock_tts_player(),
         display=display or _make_mock_display(),
         config=config or OrchestratorConfig(min_words=1),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Startup display
+# ---------------------------------------------------------------------------
+
+
+async def test_run_displays_initial_idle_state_on_startup() -> None:
+    """run() immediately shows the initial IDLE state via display.on_state_change.
+
+    Regression: previously the initial IDLE state was never displayed because
+    on_state_change was only called on transitions, leaving the terminal blank
+    after launch with no feedback that the assistant was running.
+    """
+    display = _make_mock_display()
+    orchestrator = _make_orchestrator(display=display)
+
+    task = asyncio.create_task(orchestrator.run())
+    await asyncio.sleep(0)  # yield to let run() execute until bus.get() blocks
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    cast(MagicMock, display).on_state_change.assert_called_with(
+        AssistantState.IDLE, AssistantState.IDLE
     )
 
 
@@ -124,9 +152,10 @@ async def test_idle_wake_word_transitions_to_listening() -> None:
     cast(AsyncMock, transcriber.start).assert_awaited_once()
 
 
-async def test_idle_audio_frame_ignored_without_wake_word_detector() -> None:
-    """AudioFrame in IDLE does not cause a state change (keyboard detector, no Porcupine)."""
+async def test_idle_audio_frame_without_detection_stays_idle() -> None:
+    """AudioFrame in IDLE with no detection does not cause a state change."""
     orchestrator = _make_orchestrator()
+    cast(MagicMock, orchestrator._wake_word_detector).process.return_value = False
     await orchestrator._dispatch(AudioFrame(data=b"\x00" * 1024))
     assert orchestrator._state == AssistantState.IDLE
 
@@ -176,6 +205,17 @@ async def test_listening_utterance_end_enough_words_transitions_to_processing() 
 
     assert orchestrator._state == AssistantState.PROCESSING
     cast(AsyncMock, transcriber.stop).assert_awaited_once()
+
+
+async def test_listening_utterance_end_enough_words_calls_on_user_input() -> None:
+    """UtteranceEnd with enough words → display.on_user_input called with transcript."""
+    display = _make_mock_display()
+    orchestrator = _make_orchestrator(display=display, config=OrchestratorConfig(min_words=2))
+    orchestrator._state = AssistantState.LISTENING
+
+    await orchestrator._dispatch(UtteranceEnd(transcript="hello world"))
+
+    cast(MagicMock, display).on_user_input.assert_called_once_with("hello world")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/voice/test_wakeword.py
+++ b/tests/voice/test_wakeword.py
@@ -1,4 +1,4 @@
-"""Tests for WakeWordDetector and KeyboardWakeWordDetector."""
+"""Tests for WakeWordDetector."""
 
 import struct
 import sys
@@ -116,3 +116,62 @@ def test_wake_word_detector_close_calls_delete() -> None:
         detector.close()
 
     fake_porcupine.delete.assert_called_once()
+
+
+def test_wake_word_detector_buffers_small_chunks_until_full_frame() -> None:
+    """process() buffers sub-frame chunks and only calls porcupine with full frames.
+
+    Regression: sounddevice with latency="low" delivers chunks as small as 15
+    samples, but Porcupine requires exactly frame_length (512) samples.
+    """
+    fake_porcupine = _make_fake_porcupine(detect_result=-1)
+    fake_pvporcupine = MagicMock()
+    fake_pvporcupine.create.return_value = fake_porcupine
+
+    chunk_size = 15
+    chunk = _make_silent_frame(chunk_size)
+    full_frame_size = 512
+
+    with patch.dict(sys.modules, {"pvporcupine": fake_pvporcupine}):
+        from max_ai.voice.wakeword import WakeWordDetector
+
+        detector = WakeWordDetector(access_key="key")
+
+        # Feed chunks until just before a full frame is complete.
+        chunks_per_frame = full_frame_size // chunk_size  # 34 chunks = 510 samples
+        for _ in range(chunks_per_frame):
+            result = detector.process(chunk)
+            assert result is False
+
+        # Porcupine must not have been called yet (only 510 of 512 samples buffered).
+        fake_porcupine.process.assert_not_called()
+
+        # Feed the remaining 2 samples to complete the first frame.
+        remaining = _make_silent_frame(full_frame_size - chunk_size * chunks_per_frame)
+        result = detector.process(remaining)
+
+    assert result is False
+    fake_porcupine.process.assert_called_once()
+    called_samples = fake_porcupine.process.call_args[0][0]
+    assert len(called_samples) == full_frame_size
+
+
+def test_wake_word_detector_detects_across_small_chunks() -> None:
+    """process() returns True when detection occurs after buffering sub-frame chunks."""
+    fake_porcupine = _make_fake_porcupine(detect_result=0)  # detection on every call
+    fake_pvporcupine = MagicMock()
+    fake_pvporcupine.create.return_value = fake_porcupine
+
+    full_frame = _make_silent_frame(512)
+
+    with patch.dict(sys.modules, {"pvporcupine": fake_pvporcupine}):
+        from max_ai.voice.wakeword import WakeWordDetector
+
+        detector = WakeWordDetector(access_key="key")
+        # Feed 256 samples twice to form one complete frame.
+        result_first_half = detector.process(_make_silent_frame(256))
+        result_second_half = detector.process(_make_silent_frame(256))
+
+    assert result_first_half is False  # frame not complete yet
+    assert result_second_half is True  # frame complete, detection triggered
+    del full_frame

--- a/uv.lock
+++ b/uv.lock
@@ -341,29 +341,6 @@ wheels = [
 ]
 
 [[package]]
-name = "cuda-bindings"
-version = "12.9.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-pathfinder" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
-]
-
-[[package]]
-name = "cuda-pathfinder"
-version = "1.4.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/60/d8f1dbfb7f06b94c662e98c95189e6f39b817da638bc8fcea0d003f89e5d/cuda_pathfinder-1.4.0-py3-none-any.whl", hash = "sha256:437079ca59e7b61ae439ecc501d69ed87b3accc34d58153ef1e54815e2c2e118", size = 38406, upload-time = "2026-02-25T22:13:00.807Z" },
-]
-
-[[package]]
 name = "cycler"
 version = "0.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -501,15 +478,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/40/cc11f378b561a67bea850ab50063366a0d1dd3f6d0a30ce0f874b0ad5664/fonttools-4.61.1-cp314-cp314t-win32.whl", hash = "sha256:aed04cabe26f30c1647ef0e8fbb207516fd40fe9472e9439695f5c6998e60ac5", size = 2335377, upload-time = "2025-12-12T17:31:16.49Z" },
     { url = "https://files.pythonhosted.org/packages/e4/ff/c9a2b66b39f8628531ea58b320d66d951267c98c6a38684daa8f50fb02f8/fonttools-4.61.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2180f14c141d2f0f3da43f3a81bc8aa4684860f6b0e6f9e165a4831f24e6a23b", size = 2400613, upload-time = "2025-12-12T17:31:18.769Z" },
     { url = "https://files.pythonhosted.org/packages/c7/4e/ce75a57ff3aebf6fc1f4e9d508b8e5810618a33d900ad6c19eb30b290b97/fonttools-4.61.1-py3-none-any.whl", hash = "sha256:17d2bf5d541add43822bcf0c43d7d847b160c9bb01d15d5007d84e2217aaa371", size = 1148996, upload-time = "2025-12-12T17:31:21.03Z" },
-]
-
-[[package]]
-name = "fsspec"
-version = "2026.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/7c/f60c259dcbf4f0c47cc4ddb8f7720d2dcdc8888c8e5ad84c73ea4531cc5b/fsspec-2026.2.0.tar.gz", hash = "sha256:6544e34b16869f5aacd5b90bdf1a71acb37792ea3ddf6125ee69a22a53fb8bff", size = 313441, upload-time = "2026-02-05T21:50:53.743Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/ab/fb21f4c939bb440104cc2b396d3be1d9b7a9fd3c6c2a53d98c45b3d7c954/fsspec-2026.2.0-py3-none-any.whl", hash = "sha256:98de475b5cb3bd66bedd5c4679e87b4fdfe1a3bf4d707b151b3c07e58c9a2437", size = 202505, upload-time = "2026-02-05T21:50:51.819Z" },
 ]
 
 [[package]]
@@ -1128,10 +1096,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
-wake-word = [
-    { name = "pvporcupine" },
-    { name = "torch" },
-]
 
 [package.metadata]
 requires-dist = [
@@ -1148,7 +1112,6 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pvporcupine", specifier = ">=4.0.2" },
-    { name = "pvporcupine", marker = "extra == 'wake-word'", specifier = ">=3.0" },
     { name = "pydantic-settings", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
@@ -1158,9 +1121,8 @@ requires-dist = [
     { name = "soundfile", specifier = ">=0.12.1" },
     { name = "spotipy", specifier = ">=2.23.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
-    { name = "torch", marker = "extra == 'wake-word'", specifier = ">=2.0" },
 ]
-provides-extras = ["dev", "wake-word"]
+provides-extras = ["dev"]
 
 [[package]]
 name = "mdurl"
@@ -1169,15 +1131,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
-]
-
-[[package]]
-name = "mpmath"
-version = "1.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
 ]
 
 [[package]]
@@ -1229,15 +1182,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b7/9d/0250bf5935d88e214df469d35eccc0f6ff7e9db046fc8a9aeb4b2a192775/nanoid-2.0.0.tar.gz", hash = "sha256:5a80cad5e9c6e9ae3a41fa2fb34ae189f7cb420b2a5d8f82bd9d23466e4efa68", size = 3290, upload-time = "2018-11-20T14:45:51.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/0d/8630f13998638dc01e187fadd2e5c6d42d127d08aeb4943d231664d6e539/nanoid-2.0.0-py3-none-any.whl", hash = "sha256:90aefa650e328cffb0893bbd4c236cfd44c48bc1f2d0b525ecc53c3187b653bb", size = 5844, upload-time = "2018-11-20T14:45:50.165Z" },
-]
-
-[[package]]
-name = "networkx"
-version = "3.6.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
 ]
 
 [[package]]
@@ -1324,140 +1268,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a5/55/6e1a61ded7af8df04016d81b5b02daa59f2ea9252ee0397cb9f631efe9e5/numpy-2.4.2-cp314-cp314t-win32.whl", hash = "sha256:8c50dd1fc8826f5b26a5ee4d77ca55d88a895f4e4819c7ecc2a9f5905047a443", size = 6153937, upload-time = "2026-01-31T23:12:47.229Z" },
     { url = "https://files.pythonhosted.org/packages/45/aa/fa6118d1ed6d776b0983f3ceac9b1a5558e80df9365b1c3aa6d42bf9eee4/numpy-2.4.2-cp314-cp314t-win_amd64.whl", hash = "sha256:fcf92bee92742edd401ba41135185866f7026c502617f422eb432cfeca4fe236", size = 12631844, upload-time = "2026-01-31T23:12:48.997Z" },
     { url = "https://files.pythonhosted.org/packages/32/0a/2ec5deea6dcd158f254a7b372fb09cfba5719419c8d66343bab35237b3fb/numpy-2.4.2-cp314-cp314t-win_arm64.whl", hash = "sha256:1f92f53998a17265194018d1cc321b2e96e900ca52d54c7c77837b71b9465181", size = 10565379, upload-time = "2026-01-31T23:12:51.345Z" },
-]
-
-[[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
-]
-
-[[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
-]
-
-[[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
-]
-
-[[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
-]
-
-[[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
-]
-
-[[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
-]
-
-[[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.4.5"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/09/6ea3ea725f82e1e76684f0708bbedd871fc96da89945adeba65c3835a64c/nvidia_nvshmem_cu12-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:042f2500f24c021db8a06c5eec2539027d57460e1c1a762055a6554f72c369bd", size = 139103095, upload-time = "2025-09-06T00:32:31.266Z" },
-]
-
-[[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
 ]
 
 [[package]]
@@ -1651,15 +1461,15 @@ wheels = [
 
 [[package]]
 name = "opentelemetry-semantic-conventions-ai"
-version = "0.4.14"
+version = "0.4.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/33/f77151a8c9bf93094074533ea751305e9f3fec1a4197b0f218d09cb8dce2/opentelemetry_semantic_conventions_ai-0.4.14.tar.gz", hash = "sha256:0495774011933010db7dbfa5111a2fa649edeedef922e39c898154c81eae89d8", size = 18418, upload-time = "2026-02-22T20:25:34.42Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e9/75/455c15f8360b475dd31101a87eab316420388486f7941bf019cbf4e63d5b/opentelemetry_semantic_conventions_ai-0.4.15.tar.gz", hash = "sha256:12de172d1e11d21c6e82bbf578c7e8a713589a7fda76af9ed785632564a28b81", size = 18595, upload-time = "2026-03-02T15:36:50.254Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/d5/cdc62ce0f7357cd91682bb1e31d7a68a3c0da5abdbd8c69ffa9aec555f1b/opentelemetry_semantic_conventions_ai-0.4.14-py3-none-any.whl", hash = "sha256:218e0bf656b1d459c5bc608e2a30272b7ab0a4a5b69c1bd5b659c3918f4ad144", size = 5824, upload-time = "2026-02-22T20:25:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/12/49/819fb212386f77cfd93f81bd916d674f0e735f87c8ac2262ed14e3b852c2/opentelemetry_semantic_conventions_ai-0.4.15-py3-none-any.whl", hash = "sha256:011461f1fba30f27035c49ab3b8344367adc72da0a6c8d3c7428303c6779edc9", size = 5999, upload-time = "2026-03-02T15:36:51.44Z" },
 ]
 
 [[package]]
@@ -2299,15 +2109,6 @@ wheels = [
 ]
 
 [[package]]
-name = "setuptools"
-version = "82.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
-]
-
-[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2426,18 +2227,6 @@ asyncio = [
 ]
 
 [[package]]
-name = "sympy"
-version = "1.14.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mpmath" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
-]
-
-[[package]]
 name = "tenacity"
 version = "9.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2456,61 +2245,6 @@ wheels = [
 ]
 
 [[package]]
-name = "torch"
-version = "2.10.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "cuda-bindings", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/af/758e242e9102e9988969b5e621d41f36b8f258bb4a099109b7a4b4b50ea4/torch-2.10.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5fd4117d89ffd47e3dcc71e71a22efac24828ad781c7e46aaaf56bf7f2796acf", size = 145996088, upload-time = "2026-01-21T16:24:44.171Z" },
-    { url = "https://files.pythonhosted.org/packages/23/8e/3c74db5e53bff7ed9e34c8123e6a8bfef718b2450c35eefab85bb4a7e270/torch-2.10.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:787124e7db3b379d4f1ed54dd12ae7c741c16a4d29b49c0226a89bea50923ffb", size = 915711952, upload-time = "2026-01-21T16:23:53.503Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/6f/f2e91e34e3fcba2e3fc8d8f74e7d6c22e74e480bbd1db7bc8900fdf3e95c/torch-2.10.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5c4d217b14741e40776dd7074d9006fd28b8a97ef5654db959d8635b2fe5f29b", size = 146004247, upload-time = "2026-01-21T16:24:29.335Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fb/5160261aeb5e1ee12ee95fe599d0541f7c976c3701d607d8fc29e623229f/torch-2.10.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6b71486353fce0f9714ca0c9ef1c850a2ae766b409808acd58e9678a3edb7738", size = 915716445, upload-time = "2026-01-21T16:22:45.353Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/14/21fbce63bc452381ba5f74a2c0a959fdf5ad5803ccc0c654e752e0dbe91a/torch-2.10.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:aae1b29cd68e50a9397f5ee897b9c24742e9e306f88a807a27d617f07adb3bd8", size = 146005472, upload-time = "2026-01-21T16:22:29.022Z" },
-    { url = "https://files.pythonhosted.org/packages/54/fd/b207d1c525cb570ef47f3e9f836b154685011fce11a2f444ba8a4084d042/torch-2.10.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6021db85958db2f07ec94e1bc77212721ba4920c12a18dc552d2ae36a3eb163f", size = 915612644, upload-time = "2026-01-21T16:21:47.019Z" },
-    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
-    { url = "https://files.pythonhosted.org/packages/69/2b/51e663ff190c9d16d4a8271203b71bc73a16aa7619b9f271a69b9d4a936b/torch-2.10.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:233aed0659a2503b831d8a67e9da66a62c996204c0bba4f4c442ccc0c68a3f60", size = 146018567, upload-time = "2026-01-21T16:22:23.393Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/cd/4b95ef7f293b927c283db0b136c42be91c8ec6845c44de0238c8c23bdc80/torch-2.10.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:682497e16bdfa6efeec8cde66531bc8d1fbbbb4d8788ec6173c089ed3cc2bfe5", size = 915721646, upload-time = "2026-01-21T16:21:16.983Z" },
-    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/65/1a05346b418ea8ccd10360eef4b3e0ce688fba544e76edec26913a8d0ee0/torch-2.10.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:716b01a176c2a5659c98f6b01bf868244abdd896526f1c692712ab36dbaf9b63", size = 146006482, upload-time = "2026-01-21T16:22:18.42Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/b9/5f6f9d9e859fc3235f60578fa64f52c9c6e9b4327f0fe0defb6de5c0de31/torch-2.10.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:d8f5912ba938233f86361e891789595ff35ca4b4e2ac8fe3670895e5976731d6", size = 915613050, upload-time = "2026-01-21T16:20:49.035Z" },
-    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2520,18 +2254,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
-name = "triton"
-version = "3.6.0"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/a8/cdf8b3e4c98132f965f88c2313a4b493266832ad47fb52f23d14d4f86bb5/triton-3.6.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:74caf5e34b66d9f3a429af689c1c7128daba1d8208df60e81106b115c00d6fca", size = 188266850, upload-time = "2026-01-20T16:00:43.041Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/0b/37d991d8c130ce81a8728ae3c25b6e60935838e9be1b58791f5997b24a54/triton-3.6.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c7f76c6e72d2ef08df639e3d0d30729112f47a56b0c81672edc05ee5116ac9", size = 188289450, upload-time = "2026-01-20T16:00:49.136Z" },
-    { url = "https://files.pythonhosted.org/packages/35/f8/9c66bfc55361ec6d0e4040a0337fb5924ceb23de4648b8a81ae9d33b2b38/triton-3.6.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d002e07d7180fd65e622134fbd980c9a3d4211fb85224b56a0a0efbd422ab72f", size = 188400296, upload-time = "2026-01-20T16:00:56.042Z" },
-    { url = "https://files.pythonhosted.org/packages/df/3d/9e7eee57b37c80cec63322c0231bb6da3cfe535a91d7a4d64896fcb89357/triton-3.6.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a17a5d5985f0ac494ed8a8e54568f092f7057ef60e1b0fa09d3fd1512064e803", size = 188273063, upload-time = "2026-01-20T16:01:07.278Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/56/6113c23ff46c00aae423333eb58b3e60bdfe9179d542781955a5e1514cb3/triton-3.6.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:46bd1c1af4b6704e554cad2eeb3b0a6513a980d470ccfa63189737340c7746a7", size = 188397994, upload-time = "2026-01-20T16:01:14.236Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Fix `WakeWordDetector` to buffer incoming audio bytes until a full Porcupine frame is available; small sounddevice chunks previously caused frame underflows and missed detections
- Fix `TTSPlayer` to query the output device's channel count and write audio to all channels, preventing silent playback on multi-channel (stereo) devices
- Remove `KeyboardWakeWordDetector` (push-to-talk fallback); Picovoice wake word is now a hard requirement — `pvporcupine` moves from the optional `wake-word` extra to main dependencies, and `cli.py` exits early if `MAX_AI_PICOVOICE_ACCESS_KEY` is unset
- Add `Display.on_user_input(transcript)` so transcribed text appears in the terminal before the agent responds
- Improve terminal formatting: state labels and agent prefix now start on fresh lines instead of overwriting the current line with `\r`

## Test plan

- [x] `make lint` — passes
- [x] `make typecheck` — passes
- [x] `make test` — 134 tests pass (added tests for frame buffering, multi-chunk detection, `on_user_input`, orchestrator calling `on_user_input`, and CLI always using `WakeWordDetector`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)